### PR TITLE
Handle UI updates after app reopens from background

### DIFF
--- a/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseActivity.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseActivity.kt
@@ -74,10 +74,9 @@ abstract class BaseActivity<V : ViewModel> : AppCompatActivity() {
     ) {
         val initialPage = viewConfig.initialPage
 
-        if (this is HasFragmentFlow && initialPage >= 0) {
-            flowTo(initialPage, false, savedInstanceState)
-        } else if (this !is HasFragmentFlow && initialPage >= 0) {
-            Log.e(
+        if (initialPage >= 0) {
+            if (this is HasFragmentFlow) flowTo(initialPage, false, savedInstanceState)
+            else Log.e(
                 className,
                 "Found an initialPage to display (#$initialPage), but $className does not implement " + HasFragmentFlow::class.simpleName
             )

--- a/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseActivity.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseActivity.kt
@@ -1,6 +1,7 @@
 package knaufdan.android.simpletimerapp.arch
 
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
@@ -24,6 +25,8 @@ abstract class BaseActivity<V : ViewModel> : AppCompatActivity() {
 
     protected abstract fun configureView(): ViewConfig
 
+    protected var className: String? = this::class.simpleName
+
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
@@ -34,7 +37,9 @@ abstract class BaseActivity<V : ViewModel> : AppCompatActivity() {
 
         setBinding(viewConfig, savedInstanceState)
 
-        viewConfig.titleRes?.let { setTitle(it) }
+        setTitle(viewConfig.titleRes)
+
+        showInitialPage(viewConfig, savedInstanceState)
     }
 
     private fun setBinding(
@@ -42,11 +47,11 @@ abstract class BaseActivity<V : ViewModel> : AppCompatActivity() {
         savedInstanceState: Bundle?
     ) {
         checkNotNull(viewConfig.layoutRes) {
-            "Activity parameters for " + this::class.simpleName + " have no layout resource."
+            "Activity parameters for $className have no layout resource."
         }
 
         checkNotNull(viewConfig.viewModelKey) {
-            "Activity parameters for " + this::class.simpleName + " have no viewModel key."
+            "Activity parameters for $className have no viewModel key."
         }
 
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(typeOfViewModel)
@@ -59,8 +64,24 @@ abstract class BaseActivity<V : ViewModel> : AppCompatActivity() {
         }
 
         val binding = DataBindingUtil.setContentView<ViewDataBinding>(this, viewConfig.layoutRes)
-        binding.setLifecycleOwner(this)
+        binding.lifecycleOwner = this
         binding.setVariable(viewConfig.viewModelKey, viewModel)
+    }
+
+    private fun showInitialPage(
+        viewConfig: ViewConfig,
+        savedInstanceState: Bundle?
+    ) {
+        val initialPage = viewConfig.initialPage
+
+        if (this is HasFragmentFlow && initialPage >= 0) {
+            flowTo(initialPage, false, savedInstanceState)
+        } else if (this !is HasFragmentFlow && initialPage >= 0) {
+            Log.e(
+                className,
+                "Found an initialPage to display (#$initialPage), but $className does not implement " + HasFragmentFlow::class.simpleName
+            )
+        }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseFragment.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseFragment.kt
@@ -24,7 +24,7 @@ abstract class BaseFragment<V : ViewModel> : Fragment() {
 
     protected abstract fun configureView(): ViewConfig
 
-    protected var backPressed = false
+    protected var isBackPressed = false
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -52,7 +52,7 @@ abstract class BaseFragment<V : ViewModel> : Fragment() {
         }
 
         val binding: ViewDataBinding = DataBindingUtil.inflate(inflater, config.layoutRes, container, false)
-        binding.setLifecycleOwner(this)
+        binding.lifecycleOwner = this
         binding.setVariable(config.viewModelKey, viewModel)
 
         return binding.root
@@ -60,11 +60,11 @@ abstract class BaseFragment<V : ViewModel> : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        backPressed = false
+        isBackPressed = false
     }
 
     fun onBackPress() {
-        backPressed = true
+        isBackPressed = true
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseViewModel.kt
@@ -6,9 +6,7 @@ import androidx.lifecycle.ViewModel
 
 abstract class BaseViewModel : ViewModel() {
 
-    protected var tag: String = this.javaClass.name
+    protected var className: String? = this::class.simpleName
 
-    open fun init(bundle: Bundle?) {
-        //can be overwritten
-    }
+    open fun init(bundle: Bundle?) {}
 }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/arch/ViewConfig.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/arch/ViewConfig.kt
@@ -2,16 +2,19 @@ package knaufdan.android.simpletimerapp.arch
 
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
+import knaufdan.android.simpletimerapp.R
 
 class ViewConfig(
     @LayoutRes val layoutRes: Int?,
     val viewModelKey: Int?,
-    @StringRes val titleRes: Int?
+    @StringRes val titleRes: Int,
+    val initialPage: Int
 ) {
     data class Builder(
         var layoutRes: Int? = null,
         var viewModelKey: Int? = null,
-        var titleRes: Int? = null
+        var titleRes: Int = R.string.app_name,
+        var initialPage: Int = -1
     ) {
         fun setLayoutRes(layoutRes: Int) = apply { this.layoutRes = layoutRes }
 
@@ -19,6 +22,10 @@ class ViewConfig(
 
         fun setTitleRes(titleRes: Int) = apply { this.titleRes = titleRes }
 
-        fun build() = ViewConfig(layoutRes, viewModelKey, titleRes)
+        fun setInitialPage(initialPage: Enum<*>) = setInitialPage(initialPage.ordinal)
+
+        fun setInitialPage(initialPage: Int) = apply { this.initialPage = initialPage }
+
+        fun build() = ViewConfig(layoutRes, viewModelKey, titleRes, initialPage)
     }
 }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/di/vm/ViewModelKey.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/di/vm/ViewModelKey.kt
@@ -2,10 +2,9 @@ package knaufdan.android.simpletimerapp.di.vm
 
 import androidx.lifecycle.ViewModel
 import dagger.MapKey
-import java.lang.annotation.Documented
 import kotlin.reflect.KClass
 
-@Documented
+@MustBeDocumented
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
 @Retention(AnnotationRetention.RUNTIME)
 @MapKey

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/MainActivity.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/MainActivity.kt
@@ -10,13 +10,27 @@ import knaufdan.android.simpletimerapp.arch.ViewConfig
 import knaufdan.android.simpletimerapp.ui.fragments.InputFragment
 import knaufdan.android.simpletimerapp.ui.fragments.TimerFragment
 import knaufdan.android.simpletimerapp.ui.navigation.FragmentPage
+import knaufdan.android.simpletimerapp.ui.navigation.FragmentPage.INPUT
+import knaufdan.android.simpletimerapp.ui.navigation.FragmentPage.TIMER
+import knaufdan.android.simpletimerapp.util.Constants.STATE_KEY
+import knaufdan.android.simpletimerapp.util.SharedPrefService
+import knaufdan.android.simpletimerapp.util.service.TimerState
+import javax.inject.Inject
 
 class MainActivity : BaseActivity<MainActivityViewModel>(), HasFragmentFlow {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    @Inject
+    lateinit var sharedPrefService: SharedPrefService
 
-        flowTo(FragmentPage.INPUT.ordinal, false, savedInstanceState)
+    override fun onResume() {
+        super.onResume()
+
+        val state = sharedPrefService.retrieveString(STATE_KEY)
+
+        if (TimerState.FINISH_STATE.name == state) {
+            supportFragmentManager.popBackStackImmediate()
+            flowTo(INPUT.ordinal, false, null)
+        }
     }
 
     override fun flowTo(pageNumber: Int, addToBackStack: Boolean, bundle: Bundle?) {
@@ -34,8 +48,8 @@ class MainActivity : BaseActivity<MainActivityViewModel>(), HasFragmentFlow {
 
     private fun determineFragment(page: FragmentPage, bundle: Bundle?) =
         when (page) {
-            FragmentPage.INPUT -> InputFragment()
-            FragmentPage.TIMER -> TimerFragment().apply { arguments = bundle }
+            INPUT -> InputFragment()
+            TIMER -> TimerFragment().apply { arguments = bundle }
         }
 
     override fun onBackPressed() {
@@ -53,6 +67,7 @@ class MainActivity : BaseActivity<MainActivityViewModel>(), HasFragmentFlow {
             .setLayoutRes(R.layout.activity_main)
             .setViewModelKey(BR.viewModel)
             .setTitleRes(R.string.app_name)
+            .setInitialPage(INPUT)
             .build()
 }
 

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/MainActivityViewModel.kt
@@ -1,14 +1,6 @@
 package knaufdan.android.simpletimerapp.ui
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import javax.inject.Inject
 
-class MainActivityViewModel @Inject constructor() : ViewModel() {
-
-    val name: MutableLiveData<String> = MutableLiveData()
-
-    init {
-        name.value = "New Project :: start"
-    }
-}
+class MainActivityViewModel @Inject constructor() : ViewModel()

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/InputFragmentViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/InputFragmentViewModel.kt
@@ -6,9 +6,15 @@ import androidx.lifecycle.MutableLiveData
 import knaufdan.android.simpletimerapp.arch.BaseViewModel
 import knaufdan.android.simpletimerapp.ui.navigation.Navigator
 import knaufdan.android.simpletimerapp.util.Constants.MINUTE
+import knaufdan.android.simpletimerapp.util.Constants.STATE_KEY
+import knaufdan.android.simpletimerapp.util.SharedPrefService
+import knaufdan.android.simpletimerapp.util.service.TimerState
 import javax.inject.Inject
 
-class InputFragmentViewModel @Inject constructor(private val navigator: Navigator) : BaseViewModel() {
+class InputFragmentViewModel @Inject constructor(
+    private val navigator: Navigator,
+    sharedPrefService: SharedPrefService
+) : BaseViewModel() {
 
     val timePerCycle: MutableLiveData<Int?> = MutableLiveData()
 
@@ -19,6 +25,8 @@ class InputFragmentViewModel @Inject constructor(private val navigator: Navigato
     }
 
     init {
+        sharedPrefService.saveTo(STATE_KEY, TimerState.RESET_STATE)
+
         timePerCycle.value = 1
 
         isEnabled.addSource(timePerCycle) {

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragment.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragment.kt
@@ -8,17 +8,25 @@ import knaufdan.android.simpletimerapp.arch.ViewConfig
 class TimerFragment : BaseFragment<TimerFragmentViewModel>() {
 
     override fun configureView(): ViewConfig = ViewConfig.Builder()
-            .setLayoutRes(R.layout.timer_fragment)
-            .setViewModelKey(BR.viewModel)
-            .build()
+        .setLayoutRes(R.layout.timer_fragment)
+        .setViewModelKey(BR.viewModel)
+        .build()
 
     override fun onPause() {
         super.onPause()
 
         viewModel.stopReceivingUpdates()
 
-        if (!backPressed) {
-            viewModel.setUpAlarm()
+        if (doNotSetUpAlarm()) {
+            return
         }
+        viewModel.setUpAlarm()
+    }
+
+    private fun doNotSetUpAlarm() = isBackPressed || viewModel.isFinished()
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.restart()
     }
 }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
@@ -5,23 +5,32 @@ import knaufdan.android.simpletimerapp.arch.BaseViewModel
 import knaufdan.android.simpletimerapp.ui.navigation.Navigator
 import knaufdan.android.simpletimerapp.ui.progressbar.ProgressBarViewModel
 import knaufdan.android.simpletimerapp.ui.progressbar.TimerProgressViewModel
+import knaufdan.android.simpletimerapp.util.Constants.CURRENT_TIME_KEY
 import knaufdan.android.simpletimerapp.util.Constants.END_TIME_KEY
 import knaufdan.android.simpletimerapp.util.Constants.INCREMENT_KEY
+import knaufdan.android.simpletimerapp.util.Constants.PAUSE_TIME_KEY
 import knaufdan.android.simpletimerapp.util.Constants.SECOND
+import knaufdan.android.simpletimerapp.util.Constants.STATE_KEY
+import knaufdan.android.simpletimerapp.util.SharedPrefService
 import knaufdan.android.simpletimerapp.util.alarm.AlarmService
 import knaufdan.android.simpletimerapp.util.broadcastreceiver.BroadcastUtil
 import knaufdan.android.simpletimerapp.util.broadcastreceiver.UpdateReceiver
 import knaufdan.android.simpletimerapp.util.service.Action
 import knaufdan.android.simpletimerapp.util.service.ServiceUtil
 import knaufdan.android.simpletimerapp.util.service.TimerService
+import knaufdan.android.simpletimerapp.util.service.TimerState
+import java.util.*
 import javax.inject.Inject
 
 class TimerFragmentViewModel @Inject constructor(
     private val alarmService: AlarmService,
     private val broadcastUtil: BroadcastUtil,
     private val navigator: Navigator,
-    private val serviceUtil: ServiceUtil
+    private val serviceUtil: ServiceUtil,
+    private val sharedPrefService: SharedPrefService
 ) : BaseViewModel(), ProgressBarViewModel by TimerProgressViewModel() {
+
+    var timerFinished = false
 
     private val updateReceiver =
         UpdateReceiver(Action.values()) { action: String, extras: Bundle? -> perform(action, extras) }
@@ -39,6 +48,7 @@ class TimerFragmentViewModel @Inject constructor(
     }
 
     private fun finish() {
+        timerFinished = true
         stopReceivingUpdates()
         navigator.navigateToInput()
     }
@@ -59,6 +69,34 @@ class TimerFragmentViewModel @Inject constructor(
     }
 
     fun setUpAlarm() {
+        sharedPrefService.saveTo(STATE_KEY, TimerState.PAUSE_STATE)
+        sharedPrefService.saveTo(PAUSE_TIME_KEY, Date().time)
         alarmService.setAlarm(calculateRemainingProgress())
     }
+
+    fun restart() {
+        val state = sharedPrefService.retrieveString(STATE_KEY)
+
+        if (TimerState.PAUSE_STATE.name == state) {
+            alarmService.cancelAlarm()
+
+            val pauseTime = sharedPrefService.retrieveLong(PAUSE_TIME_KEY)
+            val delta = (Date().time - pauseTime).toInt()
+            increaseProgress(delta)
+
+            val max = maximum.value ?: 0
+            val current = progress.value ?: 0
+
+            val bundle: Bundle = Bundle().apply {
+                putInt(END_TIME_KEY, max)
+                putInt(CURRENT_TIME_KEY, current.plus(delta))
+            }
+
+            serviceUtil.startService(TimerService::class, bundle)
+            broadcastUtil.registerBroadcastReceiver(updateReceiver)
+        }
+    }
+
+    fun isFinished(): Boolean = timerFinished
+            || TimerState.FINISH_STATE.name == sharedPrefService.retrieveString(STATE_KEY)
 }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
@@ -5,7 +5,7 @@ import knaufdan.android.simpletimerapp.arch.BaseViewModel
 import knaufdan.android.simpletimerapp.ui.navigation.Navigator
 import knaufdan.android.simpletimerapp.ui.progressbar.ProgressBarViewModel
 import knaufdan.android.simpletimerapp.ui.progressbar.TimerProgressViewModel
-import knaufdan.android.simpletimerapp.util.Constants.CURRENT_TIME_KEY
+import knaufdan.android.simpletimerapp.util.Constants.ADJUSTED_PROGRESS_KEY
 import knaufdan.android.simpletimerapp.util.Constants.END_TIME_KEY
 import knaufdan.android.simpletimerapp.util.Constants.INCREMENT_KEY
 import knaufdan.android.simpletimerapp.util.Constants.PAUSE_TIME_KEY
@@ -87,14 +87,16 @@ class TimerFragmentViewModel @Inject constructor(
             val max = maximum.value ?: 0
             val current = progress.value ?: 0
 
-            val bundle: Bundle = Bundle().apply {
-                putInt(END_TIME_KEY, max)
-                putInt(CURRENT_TIME_KEY, current.plus(delta))
-            }
+            val bundle: Bundle = createBundle(max, current.plus(delta))
 
             serviceUtil.startService(TimerService::class, bundle)
             broadcastUtil.registerBroadcastReceiver(updateReceiver)
         }
+    }
+
+    private fun createBundle(max: Int, adjustedTime: Int) = Bundle().apply {
+        putInt(END_TIME_KEY, max)
+        putInt(ADJUSTED_PROGRESS_KEY, adjustedTime)
     }
 
     fun isFinished(): Boolean = timerFinished

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/progressbar/TimerProgressViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/progressbar/TimerProgressViewModel.kt
@@ -11,11 +11,7 @@ class TimerProgressViewModel : ProgressBarViewModel {
         maximum.value = 0
     }
 
-    override fun increaseProgress(increment: Int) {
-        progress.postValue(progress.value?.plus(increment))
-    }
+    override fun increaseProgress(increment: Int) = progress.postValue(progress.value?.plus(increment))
 
-    override fun calculateRemainingProgress(): Long {
-        return progress.value?.let { maximum.value?.minus(it) }?.toLong() ?: 0
-    }
+    override fun calculateRemainingProgress() = progress.value?.let { maximum.value?.minus(it) }?.toLong() ?: 0
 }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/Constants.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/Constants.kt
@@ -3,7 +3,12 @@ package knaufdan.android.simpletimerapp.util
 object Constants {
     const val INCREMENT_KEY = "increment"
     const val END_TIME_KEY = "end_time"
+    const val CURRENT_TIME_KEY = "current_time"
 
     const val MINUTE = 60000
     const val SECOND = 1000
+
+    const val STATE_KEY = "knaufdan.android.simpletimerapp.state"
+
+    const val PAUSE_TIME_KEY = "knaufdan.android.simpletimerapp.pausetime"
 }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/Constants.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/Constants.kt
@@ -3,7 +3,7 @@ package knaufdan.android.simpletimerapp.util
 object Constants {
     const val INCREMENT_KEY = "increment"
     const val END_TIME_KEY = "end_time"
-    const val CURRENT_TIME_KEY = "current_time"
+    const val ADJUSTED_PROGRESS_KEY = "current_time"
 
     const val MINUTE = 60000
     const val SECOND = 1000

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/NotificationService.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/NotificationService.kt
@@ -11,15 +11,12 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.CATEGORY_ALARM
 import knaufdan.android.simpletimerapp.R
 import knaufdan.android.simpletimerapp.ui.MainActivity
-import knaufdan.android.simpletimerapp.util.Constants.STATE_KEY
-import knaufdan.android.simpletimerapp.util.service.TimerState
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class NotificationService @Inject constructor(
     private val contextProvider: ContextProvider,
-    private val sharedPrefService: SharedPrefService,
     private val textProvider: TextProvider
 ) {
 
@@ -30,8 +27,6 @@ class NotificationService @Inject constructor(
 
     fun sendTimerFinishedNotification() {
         createNotificationChannel()
-
-        sharedPrefService.saveTo(STATE_KEY, TimerState.FINISH_STATE)
 
         val notification = contextProvider.context.buildNotification()
 

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/NotificationService.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/NotificationService.kt
@@ -11,19 +11,27 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.CATEGORY_ALARM
 import knaufdan.android.simpletimerapp.R
 import knaufdan.android.simpletimerapp.ui.MainActivity
+import knaufdan.android.simpletimerapp.util.Constants.STATE_KEY
+import knaufdan.android.simpletimerapp.util.service.TimerState
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class NotificationService @Inject constructor(private val contextProvider: ContextProvider,
-                                              private val textProvider: TextProvider) {
+class NotificationService @Inject constructor(
+    private val contextProvider: ContextProvider,
+    private val sharedPrefService: SharedPrefService,
+    private val textProvider: TextProvider
+) {
 
     private val channelId = "knaufdan.android.simpletimerapp.alarm"
 
-    private val notificationManager = contextProvider.context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    private val notificationManager =
+        contextProvider.context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     fun sendTimerFinishedNotification() {
         createNotificationChannel()
+
+        sharedPrefService.saveTo(STATE_KEY, TimerState.FINISH_STATE)
 
         val notification = contextProvider.context.buildNotification()
 
@@ -32,35 +40,36 @@ class NotificationService @Inject constructor(private val contextProvider: Conte
 
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
-                && notificationManager.getNotificationChannel(channelId) == null) {
+            && notificationManager.getNotificationChannel(channelId) == null
+        ) {
             val name = textProvider.getText(R.string.timer_finished_notification_channel_name)
             val description = textProvider.getText(R.string.timer_finished_notification_channel_description)
 
             val channel = NotificationChannel(channelId, name, NotificationManager.IMPORTANCE_HIGH)
-                    .apply { this.description = description }
-                    .apply { enableVibration(true) }
+                .apply { this.description = description }
+                .apply { enableVibration(true) }
 
             notificationManager.createNotificationChannel(channel)
         }
     }
 
     private fun Context.buildNotification(): Notification =
-            NotificationCompat.Builder(this, channelId)
-                    .setSmallIcon(R.drawable.notification_important)
-                    .setContentTitle(textProvider.getText(R.string.timer_finished_notification_title))
-                    .setContentText(textProvider.getText(R.string.timer_finished_notification_content_text))
-                    .setDefaults(NotificationCompat.DEFAULT_ALL)
-                    .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-                    .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                    .setAutoCancel(true)
-                    .setCategory(CATEGORY_ALARM)
-                    .setVibrate(longArrayOf())
-                    .setContentIntent(createIntentToStartApp())
-                    .build()
+        NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.notification_important)
+            .setContentTitle(textProvider.getText(R.string.timer_finished_notification_title))
+            .setContentText(textProvider.getText(R.string.timer_finished_notification_content_text))
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .setCategory(CATEGORY_ALARM)
+            .setVibrate(longArrayOf())
+            .setContentIntent(createIntentToStartApp())
+            .build()
 
     private fun Context.createIntentToStartApp(): PendingIntent {
         val intent = Intent(this, MainActivity::class.java)
-                .apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK }
+            .apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK }
         return PendingIntent.getActivity(this, 0, intent, 0)
     }
 }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/SharedPrefService.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/SharedPrefService.kt
@@ -1,0 +1,42 @@
+package knaufdan.android.simpletimerapp.util
+
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import javax.inject.Inject
+
+class SharedPrefService @Inject constructor(private val contextProvider: ContextProvider) {
+
+    private val sharedPrefLocation = "knaufdan.android.simpletimerapp.sharedPref"
+
+    fun saveTo(key: String, value: Any) {
+        val sharedPref = getSharedPref()
+
+        with(sharedPref.edit()) {
+            putValue(value, key)
+
+            apply()
+        }
+    }
+
+    private fun SharedPreferences.Editor.putValue(value: Any, key: String) {
+        when (value) {
+            is Long -> putLong(key, value)
+            is String -> putString(key, value)
+            is Enum<*> -> putString(key, value.name)
+        }
+    }
+
+    fun retrieveString(key: String): String? {
+        val sharedPref = getSharedPref()
+
+        return sharedPref.getString(key, "")
+    }
+
+    fun retrieveLong(key: String): Long {
+        val sharedPref = getSharedPref()
+
+        return sharedPref.getLong(key, 0)
+    }
+
+    private fun getSharedPref() = contextProvider.context.getSharedPreferences(sharedPrefLocation, MODE_PRIVATE)
+}

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/alarm/AlarmReceiver.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/alarm/AlarmReceiver.kt
@@ -3,7 +3,10 @@ package knaufdan.android.simpletimerapp.util.alarm
 import android.content.Context
 import android.content.Intent
 import dagger.android.DaggerBroadcastReceiver
+import knaufdan.android.simpletimerapp.util.Constants
 import knaufdan.android.simpletimerapp.util.NotificationService
+import knaufdan.android.simpletimerapp.util.SharedPrefService
+import knaufdan.android.simpletimerapp.util.service.TimerState
 import javax.inject.Inject
 
 class AlarmReceiver : DaggerBroadcastReceiver() {
@@ -11,8 +14,13 @@ class AlarmReceiver : DaggerBroadcastReceiver() {
     @Inject
     lateinit var notificationService: NotificationService
 
+    @Inject
+    lateinit var sharedPrefService: SharedPrefService
+
     override fun onReceive(context: Context, intent: Intent) {
         super.onReceive(context, intent)
+
+        sharedPrefService.saveTo(Constants.STATE_KEY, TimerState.FINISH_STATE)
 
         notificationService.sendTimerFinishedNotification()
     }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/service/TimerService.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/service/TimerService.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.os.IBinder
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import dagger.android.AndroidInjection
-import knaufdan.android.simpletimerapp.util.Constants.CURRENT_TIME_KEY
+import knaufdan.android.simpletimerapp.util.Constants.ADJUSTED_PROGRESS_KEY
 import knaufdan.android.simpletimerapp.util.Constants.END_TIME_KEY
 import knaufdan.android.simpletimerapp.util.Constants.INCREMENT_KEY
 import knaufdan.android.simpletimerapp.util.Constants.MINUTE
@@ -36,7 +36,7 @@ class TimerService @Inject constructor() : Service() {
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
         endTime = intent.getIntExtra(END_TIME_KEY, MINUTE)
-        currentTime = intent.getIntExtra(CURRENT_TIME_KEY, DEFAULT_START_TIME)
+        currentTime = intent.getIntExtra(ADJUSTED_PROGRESS_KEY, DEFAULT_START_TIME)
         startTimerRunnable()
         return START_STICKY
     }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/service/TimerService.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/service/TimerService.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.IBinder
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import dagger.android.AndroidInjection
+import knaufdan.android.simpletimerapp.util.Constants.CURRENT_TIME_KEY
 import knaufdan.android.simpletimerapp.util.Constants.END_TIME_KEY
 import knaufdan.android.simpletimerapp.util.Constants.INCREMENT_KEY
 import knaufdan.android.simpletimerapp.util.Constants.MINUTE
@@ -15,14 +16,11 @@ import javax.inject.Inject
 class TimerService @Inject constructor() : Service() {
 
     private lateinit var manager: LocalBroadcastManager
+
     private var timer: Timer? = null
-    private var timerTask: TimerTask? = TimerRunnable(this)
 
-    private var endTime: Int = -1
     private var currentTime = 0
-
-    //define the period of time for the UI updates here
-    private val increment = SECOND * 1
+    private var endTime: Int = -1
 
     override fun onCreate() {
         AndroidInjection.inject(this)
@@ -38,24 +36,26 @@ class TimerService @Inject constructor() : Service() {
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
         endTime = intent.getIntExtra(END_TIME_KEY, MINUTE)
-        currentTime = 0
+        currentTime = intent.getIntExtra(CURRENT_TIME_KEY, DEFAULT_START_TIME)
         startTimerRunnable()
-        return Service.START_STICKY
+        return START_STICKY
     }
 
     fun sendUpdate() {
         val intent = Intent()
-            .apply { action = if (endTime <= currentTime) Action.FINISH.name else Action.INCREASE.name }
-            .apply { putExtra(INCREMENT_KEY, increment) }
+            .apply {
+                action = if (endTime <= currentTime) Action.FINISH.name else Action.INCREASE.name
+                putExtra(INCREMENT_KEY, INCREMENT)
+            }
 
-        currentTime += increment
+        currentTime = currentTime.plus(INCREMENT)
         manager.sendBroadcast(intent)
     }
 
     private fun startTimerRunnable() {
         timer = Timer()
             .apply {
-                schedule(timerTask, increment.toLong(), increment.toLong())
+                schedule(TimerRunnable(this@TimerService), INCREMENT.toLong(), INCREMENT.toLong())
             }
     }
 
@@ -63,6 +63,12 @@ class TimerService @Inject constructor() : Service() {
         super.onDestroy()
         timer?.cancel()
         timer = null
+    }
+
+    companion object {
+        //define the period of time for the UI updates here
+        const val INCREMENT = SECOND * 1
+        const val DEFAULT_START_TIME = 0
     }
 }
 

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/service/TimerState.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/service/TimerState.kt
@@ -1,0 +1,7 @@
+package knaufdan.android.simpletimerapp.util.service
+
+enum class TimerState {
+    PAUSE_STATE,
+    RESET_STATE,
+    FINISH_STATE
+}

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         lifecycle_version = '2.1.0-alpha02'
         dagger_version = '2.16'
         mockito_version = '2.8.9'
-        kotlin_version = '1.3.21'
-        gradle_version = '3.3.0'
+        kotlin_version = '1.3.31'
+        gradle_version = '3.4.1'
     }
 
     repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 21 07:33:12 CET 2019
+#Tue May 28 06:26:48 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
- define a timer state which is saved when app goes to background
- after forwarding the app again the state is received and the UI updated to show the correct progress time

- minor refactoring: build a method to set the first fragment in the viewConfig