### PR TITLE
Rename constants minute and seconds

### DIFF
--- a/app/src/main/java/knaufdan/android/simpletimerapp/databinding/BindingAdapters.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/databinding/BindingAdapters.kt
@@ -5,14 +5,14 @@ import android.widget.ArrayAdapter
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.databinding.BindingAdapter
-import knaufdan.android.simpletimerapp.util.Constants.MINUTE
-import knaufdan.android.simpletimerapp.util.Constants.SECOND
+import knaufdan.android.simpletimerapp.util.Constants.MINUTE_IN_MILLIS
+import knaufdan.android.simpletimerapp.util.Constants.SECOND_IN_MILLIS
 
 @BindingAdapter(value = ["progressText"])
 fun TextView.setProgressText(progress: Int?) {
     text = progress?.run {
-        val minutes = (this / MINUTE).addZero()
-        val seconds = (this % MINUTE / SECOND).addZero()
+        val minutes = (this / MINUTE_IN_MILLIS).addZero()
+        val seconds = (this % MINUTE_IN_MILLIS / SECOND_IN_MILLIS).addZero()
         "$minutes:$seconds"
     } ?: "00:00"
 }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/data/TimeUnit.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/data/TimeUnit.kt
@@ -6,8 +6,8 @@ enum class TimeUnit(
     val displayName: String,
     val timeInMilliSeconds: Int
 ) {
-    MINUTE("Minute", Constants.MINUTE),
-    SECOND("Second", Constants.SECOND)
+    MINUTE("Minute", Constants.MINUTE_IN_MILLIS),
+    SECOND("Second", Constants.SECOND_IN_MILLIS)
 }
 
 fun String.parseToTimeUnit() = TimeUnit.values().firstOrNull { timeUnit ->

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
@@ -12,7 +12,7 @@ import knaufdan.android.simpletimerapp.util.Constants.KEY_IS_ON_REPEAT
 import knaufdan.android.simpletimerapp.util.Constants.KEY_LINEAR_INCREMENT
 import knaufdan.android.simpletimerapp.util.Constants.KEY_PAUSE_TIME
 import knaufdan.android.simpletimerapp.util.Constants.KEY_TIMER_STATE
-import knaufdan.android.simpletimerapp.util.Constants.SECOND
+import knaufdan.android.simpletimerapp.util.Constants.SECOND_IN_MILLIS
 import knaufdan.android.simpletimerapp.util.SharedPrefService
 import knaufdan.android.simpletimerapp.util.alarm.AlarmService
 import knaufdan.android.simpletimerapp.util.broadcastreceiver.BroadcastUtil
@@ -56,7 +56,7 @@ class TimerFragmentViewModel @Inject constructor(
     }
 
     private fun increase(bundle: Bundle?) {
-        val increment = bundle?.getInt(KEY_LINEAR_INCREMENT, SECOND) ?: SECOND
+        val increment = bundle?.getInt(KEY_LINEAR_INCREMENT, SECOND_IN_MILLIS) ?: SECOND_IN_MILLIS
         increaseProgress(increment)
     }
 

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/Constants.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/Constants.kt
@@ -5,12 +5,10 @@ object Constants {
     const val KEY_CURRENT_MAXIMUM = "knaufdan.android.simpletimerapp.currentmaximum"
     const val KEY_ADJUSTED_PROGRESS = "knaufdan.android.simpletimerapp.adjustedprogress"
     const val KEY_PAUSE_TIME = "knaufdan.android.simpletimerapp.pausetime"
-
     const val KEY_IS_ON_REPEAT = "knaufdan.android.simpletimerapp.isonrepeat"
     const val KEY_TIMER_STATE = "knaufdan.android.simpletimerapp.timerstate"
-
     const val KEY_TIMER_CONFIGURATION = "knaufdan.android.simpletimerapp.timerconfiguration"
 
-    const val MINUTE = 60000
-    const val SECOND = 1000
+    const val MINUTE_IN_MILLIS = 60000
+    const val SECOND_IN_MILLIS = 1000
 }

--- a/app/src/main/java/knaufdan/android/simpletimerapp/util/service/TimerService.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/util/service/TimerService.kt
@@ -8,8 +8,8 @@ import dagger.android.AndroidInjection
 import knaufdan.android.simpletimerapp.util.Constants.KEY_ADJUSTED_PROGRESS
 import knaufdan.android.simpletimerapp.util.Constants.KEY_CURRENT_MAXIMUM
 import knaufdan.android.simpletimerapp.util.Constants.KEY_LINEAR_INCREMENT
-import knaufdan.android.simpletimerapp.util.Constants.MINUTE
-import knaufdan.android.simpletimerapp.util.Constants.SECOND
+import knaufdan.android.simpletimerapp.util.Constants.MINUTE_IN_MILLIS
+import knaufdan.android.simpletimerapp.util.Constants.SECOND_IN_MILLIS
 import java.util.Timer
 import javax.inject.Inject
 
@@ -35,7 +35,7 @@ class TimerService @Inject constructor() : Service() {
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
-        endTime = intent.getIntExtra(KEY_CURRENT_MAXIMUM, MINUTE)
+        endTime = intent.getIntExtra(KEY_CURRENT_MAXIMUM, MINUTE_IN_MILLIS)
         currentTime = intent.getIntExtra(KEY_ADJUSTED_PROGRESS, DEFAULT_START_TIME)
         startTimerRunnable()
         return START_STICKY
@@ -71,7 +71,7 @@ class TimerService @Inject constructor() : Service() {
 
     companion object {
         //define the period of time for the UI updates here
-        const val INCREMENT = SECOND * 1
+        const val INCREMENT = SECOND_IN_MILLIS * 1
         const val DEFAULT_START_TIME = 0
     }
 }


### PR DESCRIPTION
Renaming to `minutes_in_millis` and `seconds_in_millis` to make them more distinguished from the `TimeUnit` enum values and are more clear what they represent.