### PR TITLE
[bug] Strange back press behaviour

### DIFF
--- a/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseFragment.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/arch/BaseFragment.kt
@@ -17,14 +17,16 @@ import knaufdan.android.simpletimerapp.di.vm.ViewModelFactory
 
 abstract class BaseFragment<V : ViewModel> : Fragment() {
 
+    val fragmentTag = this::class.simpleName
+
+    var isBackPressed = false
+
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
     protected lateinit var viewModel: V
 
     protected abstract fun configureView(): ViewConfig
-
-    var isBackPressed = false
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/MainActivity.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/MainActivity.kt
@@ -34,7 +34,13 @@ class MainActivity : BaseActivity<MainActivityViewModel>(), HasFragmentFlow {
         val page = FragmentPage.values()[pageNumber]
         val fragmentTransaction = supportFragmentManager.beginTransaction()
 
-        fragmentTransaction.replace(R.id.fragment_container, determineFragment(page, bundle))
+        determineFragment(page, bundle).apply {
+            fragmentTransaction.replace(
+                R.id.fragment_container,
+                this,
+                this.fragmentTag
+            )
+        }
 
         if (addToBackStack) {
             fragmentTransaction.addToBackStack(null)
@@ -49,14 +55,14 @@ class MainActivity : BaseActivity<MainActivityViewModel>(), HasFragmentFlow {
             TIMER -> TimerFragment().apply { arguments = bundle }
         }
 
-    override fun onBackPressed() {
-        supportFragmentManager.fragments[0]?.let { fragment ->
+    override fun onBackPressed() = with(supportFragmentManager) {
+        fragments[0]?.let { fragment ->
             if (fragment is BaseFragment<*>) {
                 fragment.isBackPressed = true
             }
         }
 
-        if (supportFragmentManager.backStackEntryCount == 0) resetAppToStart()
+        if (backStackEntryCount == 0 && fragments[0]?.tag != InputFragment::class.simpleName) resetAppToStart()
         else super.onBackPressed()
     }
 

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
@@ -94,7 +94,7 @@ class TimerFragmentViewModel @Inject constructor(
     private fun finishAndQuit() {
         timerFinished = true
         audioService.releaseMediaPlayer()
-        navigator.navigateToInput()
+        navigator.backPressed()
     }
 
     override fun init(bundle: Bundle?) {

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/navigation/Navigator.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/navigation/Navigator.kt
@@ -1,5 +1,6 @@
 package knaufdan.android.simpletimerapp.ui.navigation
 
+import android.app.Activity
 import android.os.Bundle
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -12,32 +13,25 @@ import knaufdan.android.simpletimerapp.util.ContextProvider
 @Singleton
 class Navigator @Inject constructor(private val contextProvider: ContextProvider) {
 
-    fun navigateToInput() {
-        with(contextProvider.context) {
-            if (this is HasFragmentFlow) {
-                flowTo(
-                    pageNumber = FragmentPage.INPUT.ordinal,
-                    addToBackStack = false
-                )
-            }
+    fun navigateToTimer(
+        timerConfiguration: TimerConfiguration
+    ) = with(contextProvider.context) {
+        if (this is HasFragmentFlow) {
+            flowTo(
+                pageNumber = FragmentPage.TIMER.ordinal,
+                addToBackStack = true,
+                bundle = Bundle()
+                    .apply {
+                        putInt(KEY_CURRENT_MAXIMUM, timerConfiguration.timePerCycle)
+                        putBoolean(KEY_IS_ON_REPEAT, timerConfiguration.isOnRepeat)
+                    }
+            )
         }
     }
 
-    fun navigateToTimer(
-        timerConfiguration: TimerConfiguration
-    ) {
-        with(contextProvider.context) {
-            if (this is HasFragmentFlow) {
-                flowTo(
-                    pageNumber = FragmentPage.TIMER.ordinal,
-                    addToBackStack = true,
-                    bundle = Bundle()
-                        .apply {
-                            putInt(KEY_CURRENT_MAXIMUM, timerConfiguration.timePerCycle)
-                            putBoolean(KEY_IS_ON_REPEAT, timerConfiguration.isOnRepeat)
-                        }
-                )
-            }
+    fun backPressed() = with(contextProvider.context) {
+        if (this is Activity) {
+            onBackPressed()
         }
     }
 }


### PR DESCRIPTION
- stop recreating input fragment on backPress by checking if it's already there
- create `backPressed` method in `Navigator` to trigger navigate back in viewModel, otherwise an extra `InputFragment` is placed on stop pressed.

Bug: #71 